### PR TITLE
Added more integration between markdown and confurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Use **-l** or **--loglevel** to specify a different logging level, i.e **DEBUG**
 Use **-s** or **--simulate** to stop processing before interacting with confluence API, i.e. only
  converting the markdown document to confluence format.
 
+Use **--title** to set the title for the page, otherwise the title is going to be the first line in the markdown file
+
+Use **--remove-emojies** to emove emojies if there are any. This may be need if the database doesn't support emojies
+
 ## Markdown
 
 The original markdown to HTML conversion is performed by the Python **markdown** library.

--- a/md2conf.py
+++ b/md2conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 # --------------------------------------------------------------------------------------------------
 # Rittman Mead Markdown to Confluence Tool

--- a/md2conf.py
+++ b/md2conf.py
@@ -69,7 +69,7 @@ PARSER.add_argument('--property', action='append', dest='properties', default=[]
                     type=lambda kv: kv.split("="),
                     help='A list of content properties to set on the page.')
 PARSER.add_argument('--title', action='store', dest='title', default=None,
-                    help='Set the title for the page, otherwise the title is going to be the first line in the file')
+                    help='Set the title for the page, otherwise the title is going to be the first line in the markdown file')
 PARSER.add_argument('--remove-emojies', action='store_true', dest='remove_emojies', default=False,
                     help='Remove emojies if there are any. This may be need if the database doesn\'t support emojies')
 


### PR DESCRIPTION
- Removed hardcoded patch for python3 executable
- Added option to set page title, instead of using the first line
- Added option to filter out emojies
- Added support for the `[TOC]` markdown syntax
- Enable to extensions `footnotes` for the markdown generater
- Added default option to `--markdownsrc`
- Added more filter for `slug` function
- Changed the url link replacement for VERSION 1 to Confluence anchor link