### PR TITLE
Update md2conf.py for the SSL case

### DIFF
--- a/md2conf.py
+++ b/md2conf.py
@@ -136,7 +136,7 @@ try:
     else:
         LOGGER.error('Error: Org Name not specified by environment variable or option.')
         sys.exit(1)
-
+    CONFLUENCE_API_URL = CONFLUENCE_API_URL_TMP
     if NOSSL:
         CONFLUENCE_API_URL = CONFLUENCE_API_URL_TMP.replace('https://', 'http://')
 


### PR DESCRIPTION
This repo worked for me to make calls to the Atlassian endpoint using SSL in the past until recently.

My usage is fairly simple:
```
python "md_to_conf/md2conf.py" "markdown.md" ENG \
  -o $ORG --title "$PAGE_TITLE" -a "$ANCESTOR_PAGE" \
  -u "$CONFLUENCE_USERNAME" -p "$CONFLUENCE_API_KEY"
```

I think that this was introduced in this change https://github.com/RittmanMead/md_to_conf/commit/bbb706e812c376eb2f7cd8b1f897924b9e7b90d7.