### PR TITLE
Fix codeblock

### DIFF
--- a/md2conf.py
+++ b/md2conf.py
@@ -190,9 +190,10 @@ def convert_code_block(html):
             conf_ml = conf_ml + '<ac:parameter ac:name="theme">Midnight</ac:parameter>'
             conf_ml = conf_ml + '<ac:parameter ac:name="linenumbers">true</ac:parameter>'
 
-            lang = re.search('code class="(.*)"', tag)
+            lang = re.search('code class="language-(.*)"', tag)
             if lang:
                 lang = lang.group(1)
+                logging.debug('lang: %s', lang)
             else:
                 lang = 'none'
 

--- a/md2conf.py
+++ b/md2conf.py
@@ -182,7 +182,8 @@ def convert_code_block(html):
     :param html: string
     :return: modified html string
     """
-    code_blocks = re.findall(r'<pre><code.*?>.*?</code></pre>', html, re.DOTALL)
+
+    code_blocks = re.findall(r'<pre.*?><code.*?>.*?</code></pre>', html, re.DOTALL)
     if code_blocks:
         for tag in code_blocks:
 
@@ -198,7 +199,7 @@ def convert_code_block(html):
                 lang = 'none'
 
             conf_ml = conf_ml + '<ac:parameter ac:name="language">' + lang + '</ac:parameter>'
-            content = re.search(r'<pre><code.*?>(.*?)</code></pre>', tag, re.DOTALL).group(1)
+            content = re.search(r'<pre.*?><code.*?>(.*?)</code></pre>', tag, re.DOTALL).group(1)
             content = content.replace("]]", "]]]]><![CDATA[")
             content = '<ac:plain-text-body><![CDATA[' + content + ']]></ac:plain-text-body>'
             conf_ml = conf_ml + content + '</ac:structured-macro>'
@@ -988,7 +989,7 @@ def main():
 
     with codecs.open(MARKDOWN_FILE, 'r', 'utf-8') as mdfile:
         html = mdfile.read()
-        html = markdown.markdown(html, extensions=['tables', 'fenced_code', 'footnotes'])
+        html = markdown.markdown(html, extensions=['tables', 'fenced_code', 'footnotes', 'pymdownx.superfences'])
 
     if not TITLE:
         html = '\n'.join(html.split('\n')[1:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2023.7.22
 chardet==5.0.0
 idna==3.3
-Markdown==3.4.1
+Markdown==3.5.2
 requests==2.31.0
 urllib3==1.26.12
+pymdown-extensions


### PR DESCRIPTION
- generated markdown codeblock classes has language- prefix, but unwanted on confluence
- add superfences to markdown to prevent codeblock nested under list from resetting list number 